### PR TITLE
Фикс для бага с переходом на контент тултипа

### DIFF
--- a/src/Badge/Badge.scss
+++ b/src/Badge/Badge.scss
@@ -1,7 +1,6 @@
 .kit-badge {
 	position: relative;
 	z-index: 1;
-	overflow: hidden;
 	font-family: "PT Sans", sans-serif;
 	display: inline-flex;
 	justify-content: center;

--- a/src/Badge/Badge.tsx
+++ b/src/Badge/Badge.tsx
@@ -35,13 +35,16 @@ export const Badge: React.FC<IProps> = props => {
 		progressColor,
 		children
 	} = props;
-	const isProgressBar = progress !== undefined && !isNaN(progress);
-	let backgroundColor;
+	let background;
 
-	if (isProgressBar) {
-		backgroundColor = mode ? ProgressColors[mode] : progressColor;
+	if (progress !== undefined && !isNaN(progress)) {
+		const backgroundColor = mode ? ProgressColors[mode] : progressColor;
+		const barColor = mode ? ModeColors[mode] : color;
+
+		background = `linear-gradient(90deg, ${barColor} ${progress}%, ${backgroundColor} ${progress}%, ${backgroundColor} ${100 -
+			progress}%)`;
 	} else {
-		backgroundColor = mode ? ModeColors[mode] : color;
+		background = mode ? ModeColors[mode] : color;
 	}
 
 	return (
@@ -50,18 +53,9 @@ export const Badge: React.FC<IProps> = props => {
 				[`kit-badge_size_${size}`]: size,
 				[`kit-badge_mode_${mode}`]: mode
 			})}
-			style={{ backgroundColor }}
+			style={{ background }}
 		>
 			{children}
-			{isProgressBar && (
-				<div
-					className="kit_badge__progress-bar"
-					style={{
-						backgroundColor: mode ? ModeColors[mode] : color,
-						width: `${progress}%`
-					}}
-				/>
-			)}
 		</div>
 	);
 };

--- a/src/Tooltip/Tooltip.scss
+++ b/src/Tooltip/Tooltip.scss
@@ -102,7 +102,8 @@
 	display: block;
 	width: 100%;
 	height: 100%;
-	z-index: 1;
+	min-height: 15px;
+	z-index: 10;
 	right: 0;
 
 	&_top {


### PR DESCRIPTION
Для бейджа обрезалась дорожка из-за `overflow: hidden`, он был нужен для фона прогресс бара. заменила див для прогресса на бэкграунд с градиентом
Для таблицы не хватало высоты дорожки, она была меньше отступа для тутлтипа