### PR TITLE
[RFC][issue-739]Сломался тултип

### DIFF
--- a/src/BlockComponents/components/Wrapper/Wrapper.scss
+++ b/src/BlockComponents/components/Wrapper/Wrapper.scss
@@ -1,3 +1,9 @@
+.kit-block-wrapper {
+	> * {
+		margin-right: 5px;
+	}
+}
+
 span.kit-block-wrapper {
 	display: inline-flex;
 	align-items: center;

--- a/src/BlockComponents/components/Wrapper/Wrapper.scss
+++ b/src/BlockComponents/components/Wrapper/Wrapper.scss
@@ -1,6 +1,6 @@
 .kit-block-wrapper {
 	> * {
-		margin-right: 5px;
+		margin-left: 5px;
 	}
 }
 

--- a/src/Tooltip/Tooltip.scss
+++ b/src/Tooltip/Tooltip.scss
@@ -24,7 +24,7 @@
 	display: block;
 	box-sizing: border-box;
 	position: absolute;
-	z-index: 9;
+	z-index: 10;
 	left: 50%;
 	color: #000;
 	font-family: "PT Sans", sans-serif;


### PR DESCRIPTION
https://github.com/mindbox-moscow/ui-kit/issues/739

z-index выставил 10 это ломает отображение тултипа на странице https://test.staging.directcrm.ru/promotions/2442 он начинает наезжать на шапку, это не так критично, как то, что тултип вообще не отображается в фильтрах.