### PR TITLE
При удалении брекета торчит брекет #847

### DIFF
--- a/src/FiltrationGroupComponent/FiltrationGroupComponent.tsx
+++ b/src/FiltrationGroupComponent/FiltrationGroupComponent.tsx
@@ -82,7 +82,7 @@ const FiltrationGroupComponent: React.FC<Props & WithOutsideClickProps> = ({
 				"last"
 			);
 
-			const groupRefHeight = groupRef.getBoundingClientRect().height;
+			const groupRefHeight = groupRef.clientHeight;
 			const firstChildElementHeight = firstChildElement
 				? firstChildElement.clientHeight
 				: 0;
@@ -143,7 +143,7 @@ const FiltrationGroupComponent: React.FC<Props & WithOutsideClickProps> = ({
 					let labelLineMiddle = 0;
 
 					if (labelLine) {
-						const { height } = labelLine.getBoundingClientRect();
+						const height = labelLine.clientHeight;
 						const offsetTop = labelLine.offsetTop;
 
 						withOutLine = lastChildElementHeight - height;
@@ -377,7 +377,9 @@ const FiltrationGroupComponent: React.FC<Props & WithOutsideClickProps> = ({
 									{moreActions && moreActions.length && (
 										<ActionsDropdown
 											className="kit-filtration-group__more"
-											toggleBtnText={moreConditionToggleCaption || ""}
+											toggleBtnText={
+												moreConditionToggleCaption || ""
+											}
 											positionDropdown="right"
 										>
 											{moreActions.map((props, index) => (


### PR DESCRIPTION
https://github.com/mindbox-moscow/ui-kit/issues/847

При измененном зуме браузера `getBoundingClientRect` от дает разные значения, поэтому исправил на `clientHeight`, с ним такого поведения не возникает